### PR TITLE
enable containerd snapshotter

### DIFF
--- a/images/nomad-client/Dockerfile
+++ b/images/nomad-client/Dockerfile
@@ -2,14 +2,19 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 ENV DOCKER_RELEASES=https://download.docker.com/linux/debian/dists/bullseye/pool/stable
-ARG CONTAINERD_VERSION=1.6.9-1
-ARG DOCKER_CE_VERSION=24.0.2-1
+ARG CONTAINERD_VERSION=1.6.26-1
+ARG DOCKER_CE_VERSION=24.0.7-1
 ENV container=docker
 
 # all non-scripts are 0644 (rw- r-- r--)
 COPY --chmod=0644 rootfs/etc/nomad.d/* /etc/nomad.d/
 # all scripts are 0755 (rwx r-x r-x)
 COPY --chmod=0755 rootfs/usr/local/bin/* /usr/local/bin/
+
+# copy unit files and service configs
+COPY --chmod=0644 rootfs/etc/systemd/system/* /etc/systemd/system/
+COPY --chmod=0644 rootfs/etc/cilium/* /etc/cilium/
+COPY --chmod=0644 rootfs/etc/docker/* /etc/docker/
 
 RUN sed -i "s/^User=.*\$/User=root/g" /etc/systemd/system/nomad.service \
     && sed -i "s/^Group=.*\$/Group=root/g" /etc/systemd/system/nomad.service
@@ -34,7 +39,8 @@ RUN set -eux \
     && cd /tmp \
     && rm -rf /tmp/build
 
-RUN systemctl enable docker
+RUN systemctl enable docker.service \
+    && systemctl enable containerd.service
 
 ENV CNI_RELEASES=https://github.com/containernetworking/plugins/releases
 ARG CNI_VERSION=1.3.0
@@ -61,8 +67,6 @@ RUN mkdir -p /opt/cilium/bin \
     && mkdir -p /opt/cilium/config
 COPY --from=cilium/cilium:v1.13.5 /opt/cni/bin/cilium-cni /opt/cilium/bin/cilium-cni
 COPY --from=cilium/cilium:v1.13.5 /usr/bin/cilium* /usr/local/bin/
-COPY --chmod=0644 rootfs/etc/systemd/system/* /etc/systemd/system/
-COPY --chmod=0644 rootfs/etc/cilium/* /etc/cilium/
 COPY --chmod=0644 rootfs/opt/cni/config/* /opt/cilium/config/
 
 RUN systemctl ${CILIUM_SERVICE} cilium-mounts \

--- a/images/nomad-client/rootfs/etc/docker/daemon.json
+++ b/images/nomad-client/rootfs/etc/docker/daemon.json
@@ -1,0 +1,5 @@
+{
+  "features": {
+    "containerd-snapshotter": true
+  }
+}

--- a/images/nomad-client/rootfs/etc/systemd/system/containerd.service
+++ b/images/nomad-client/rootfs/etc/systemd/system/containerd.service
@@ -1,0 +1,28 @@
+# derived containerd systemd service file from the official:
+# https://github.com/containerd/containerd/blob/master/containerd.service
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+# disable rate limiting
+StartLimitIntervalSec=0
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=1
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target

--- a/images/nomad-client/rootfs/etc/systemd/system/docker.service
+++ b/images/nomad-client/rootfs/etc/systemd/system/docker.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network-online.target docker.socket firewalld.service containerd.service time-set.target
+Wants=network-online.target containerd.service
+Requires=docker.socket
+
+[Service]
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+ExecReload=/bin/kill -s HUP $MAINPID
+TimeoutStartSec=0
+RestartSec=2
+Restart=always
+
+# Note that StartLimit* options were moved from "Service" to "Unit" in systemd 229.
+# Both the old, and new location are accepted by systemd 229 and up, so using the old location
+# to make them work for either version of systemd.
+StartLimitBurst=3
+
+# Note that StartLimitInterval was renamed to StartLimitIntervalSec in systemd 230.
+# Both the old, and new name are accepted by systemd 230 and up, so using the old name to make
+# this option work for either version of systemd.
+StartLimitInterval=60s
+
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+
+# Comment TasksMax if your systemd version does not support it.
+# Only systemd 226 and above support this option.
+TasksMax=infinity
+
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+OOMScoreAdjust=-500
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -25,6 +25,7 @@ function docker_run {
     --security-opt seccomp=unconfined \
     --security-opt apparmor=unconfined \
     --volume /lib/modules:/lib/modules:ro \
+    --volume /var \
     ${args[@]} \
     ${image_name}:${HIND_VERSION} > /dev/null
 }


### PR DESCRIPTION
PR updates and enables containerd snapshotter to test out functionality with nomad.

changes made:
  - updated containerd version to 1.6.26
  - updated docker-ce version to 24.0.7
  - added docker daemon.json config file with containerd-snapshotter enabled
  - fixed mistake of missing out /var volume, this was causing the snapshotter to have issues mounting volumes.
  - added docker and containerd unit files in so that settings can be tinkered with easily