### PR TITLE
enable hubble/relay and upgrade cilium to v1.13.9

### DIFF
--- a/cilium/hubble-relay.hcl
+++ b/cilium/hubble-relay.hcl
@@ -1,0 +1,36 @@
+job "hubble-relay" {
+  priority = 100
+  type     = "service"
+  constraint {
+    attribute = "${attr.plugins.cni.version.cilium-cni}"
+    operator  = "is_set"
+  }
+  group "hubble-relay" {
+    service {
+      name = "hubble-relay"
+      tags = ["hubble-relay"]
+    }
+    network {
+      port "grpc" {
+        static = 4245
+        to     = 4245
+      }
+    }
+    task "hubble-relay" {
+      driver = "docker"
+      config {
+        network_mode = "host"
+        image        = "quay.io/cilium/hubble-relay:v1.13.9"
+        volumes = [
+          "/var/run/cilium/hubble.sock:/var/run/cilium/hubble.sock"
+        ]
+        ports = ["grpc"]
+        args = [
+          "serve",
+          "--disable-client-tls",
+          "--disable-server-tls",
+        ]
+      }
+    }
+  }
+}

--- a/cilium/netreap.hcl
+++ b/cilium/netreap.hcl
@@ -4,14 +4,14 @@ job "netreap" {
   type        = "system"
   constraint {
     attribute = "${attr.plugins.cni.version.cilium-cni}"
-    operator = "is_set"
+    operator  = "is_set"
   }
   group "netreap" {
     restart {
       interval = "10m"
       attempts = 5
-      delay = "15s"
-      mode = "delay"
+      delay    = "15s"
+      mode     = "delay"
     }
     service {
       name = "netreap"
@@ -21,7 +21,7 @@ job "netreap" {
       driver = "docker"
       env {
         NETREAP_CILIUM_CIDR = "10.8.0.0/16"
-        NETREAP_DEBUG = "true"
+        NETREAP_DEBUG       = "true"
       }
       config {
         image        = "ghcr.io/cosmonic/netreap:0.2.0"

--- a/images/nomad-client/Dockerfile
+++ b/images/nomad-client/Dockerfile
@@ -19,6 +19,7 @@ COPY --chmod=0644 rootfs/etc/docker/* /etc/docker/
 RUN sed -i "s/^User=.*\$/User=root/g" /etc/systemd/system/nomad.service \
     && sed -i "s/^Group=.*\$/Group=root/g" /etc/systemd/system/nomad.service
 
+# install docker-ce and containerd
 RUN set -eux \
     && apt install -y iproute2 fuse-overlayfs \
     && mkdir -p /tmp/build \
@@ -42,6 +43,7 @@ RUN set -eux \
 RUN systemctl enable docker.service \
     && systemctl enable containerd.service
 
+# install standard CNI plugins
 ENV CNI_RELEASES=https://github.com/containernetworking/plugins/releases
 ARG CNI_VERSION=1.3.0
 
@@ -61,12 +63,14 @@ RUN set -eux \
     && for file in "bridge" "dhcp" "host-local" "loopback" "firewall" "portmap" "ptp"; do cp $file /opt/cni/bin; done \
     && rm -rf /tmp/build
 
+# install cilium cni plugin and service
 ARG CILIUM_SERVICE=disable
 
 RUN mkdir -p /opt/cilium/bin \
     && mkdir -p /opt/cilium/config
-COPY --from=cilium/cilium:v1.13.5 /opt/cni/bin/cilium-cni /opt/cilium/bin/cilium-cni
-COPY --from=cilium/cilium:v1.13.5 /usr/bin/cilium* /usr/local/bin/
+COPY --from=cilium/cilium:v1.13.9 /opt/cni/bin/cilium-cni /opt/cilium/bin/cilium-cni
+COPY --from=cilium/cilium:v1.13.9 /usr/bin/cilium* /usr/local/bin/
+COPY --from=cilium/cilium:v1.13.9 /usr/bin/hubble /usr/local/bin/
 COPY --chmod=0644 rootfs/opt/cni/config/* /opt/cilium/config/
 
 RUN systemctl ${CILIUM_SERVICE} cilium-mounts \

--- a/images/nomad-client/rootfs/etc/systemd/system/cilium.service
+++ b/images/nomad-client/rootfs/etc/systemd/system/cilium.service
@@ -12,7 +12,7 @@ Restart=always
 EnvironmentFile=/etc/cilium/cilium.env
 ExecStartPre=-/usr/bin/docker exec %n stop
 ExecStartPre=-/usr/bin/docker rm %n
-ExecStartPre=-/usr/bin/docker pull cilium/cilium:v1.13.5
+ExecStartPre=-/usr/bin/docker pull cilium/cilium:v1.13.9
 ExecStart=/usr/bin/docker run --rm --name %n \
   -v /var/run/cilium:/var/run/cilium \
   -v /sys/fs/bpf:/sys/fs/bpf \
@@ -24,10 +24,13 @@ ExecStart=/usr/bin/docker run --rm --name %n \
   --cap-add SYS_ADMIN \
   --cap-add SYS_RESOURCE \
   --privileged \
-  cilium/cilium:v1.13.5 \
+  cilium/cilium:v1.13.9 \
   cilium-agent --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 \
     --enable-ipv6=false -t geneve \
     --enable-l7-proxy=false  \
+    --enable-hubble \
+    --hubble-disable-tls \
+    --hubble-listen-address ":4244" \
     --ipv4-range ${CILIUM_IPV4_RANGE}
 [Install]
 WantedBy=multi-user.target

--- a/jobs/example-cilium.hcl
+++ b/jobs/example-cilium.hcl
@@ -4,11 +4,8 @@ job "example_cilium" {
     "cosmonic.io/app_name" = "example"
   }
 
-  group "cache" {
+  group "client" {
     network {
-      port "db" {
-        to = 6379
-      }
       // This selects the CNI plugin to use.
       // The name after "cni/" should match the conflist that is configured on
       // the Nomad node.
@@ -18,18 +15,19 @@ job "example_cilium" {
 
     service {
       name         = "example"
-      port         = "db"
       tags         = ["example"]
       address_mode = "alloc"
     }
 
-    task "redis" {
+    task "client" {
       driver = "docker"
 
       config {
-        image          = "redis:7"
-        ports          = ["db"]
-        auth_soft_fail = true
+        image = "quay.io/curl/curl:latest"
+        args = [
+          "sleep",
+          "infinity"
+        ]
       }
 
       identity {

--- a/jobs/example.hcl
+++ b/jobs/example.hcl
@@ -6,9 +6,9 @@ job "example" {
       }
     }
     service {
-      name         = "example"
-      port         = "db"
-      tags         = ["example"]
+      name = "example"
+      port = "db"
+      tags = ["example"]
     }
 
     task "redis" {


### PR DESCRIPTION
Change summary:

 - enable hubble in the cilium service
 - provide nomad job to deploy the hubble-relay
 - upgrades the cilium version to v1.13.9
 - docs: update readme with hubble instructions
 - docs: improve the cilium example with easier to follow example of the initial working policy
 - other minor misc readme updates