### PR TITLE
Update hind to version 0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ CILIUM_ENABLED ?= 0
 NOMAD_CLIENT_COUNT ?= 1
 
 BASE_IMAGE = debian:bullseye-slim
-CONSUL_VERSION = 1.16.2
-NOMAD_VERSION = 1.6.3
-HIND_VERSION = 0.1.1
+CONSUL_VERSION ?= 1.18.1
+NOMAD_VERSION ?= 1.7.6
+HIND_VERSION = 0.2.0
 
 ifeq ($(DOCKER_CACHE), 0)
 docker-cache="--no-cache"

--- a/README.md
+++ b/README.md
@@ -109,12 +109,134 @@ Connected Nodes: 1/1
 ```
 
 # Requirements
-This project has been tested using MacOS, colima 0.6.x and requires cgroupsv2 enabled on the docker host.
+This project has mainly been tested using MacOS, colima 0.6.x, and requires cgroupsv2 enabled on the docker host.
 - [colima](https://github.com/abiosoft/colima)
 - [docker-cli](https://docs.docker.com/engine/install/binaries/#install-client-binaries-on-macos)
 - [buildx](https://github.com/abiosoft/colima/discussions/273)
 - [nomad](https://developer.hashicorp.com/nomad/downloads) (used for cli commands)
 - [consul](https://developer.hashicorp.com/consul/downloads) (used for cli commands)
+
+## Docker info
+System and docker information confirmed working
+1. <details><summary>Colima, 0.6.7</summary></details>
+2. <details><summary>Debian GNU/Linux 12 (bookworm) - click for details</summary>
+
+        Client: Docker Engine - Community
+         Version:    24.0.7
+         Context:    default
+         Debug Mode: false
+         Plugins:
+          buildx: Docker Buildx (Docker Inc.)
+            Version:  v0.11.2
+            Path:     /Users/user/.docker/cli-plugins/docker-buildx
+
+        Server:
+         Containers: 4
+          Running: 4
+          Paused: 0
+          Stopped: 0
+         Images: 11
+         Server Version: 25.0.0
+         Storage Driver: overlay2
+          Backing Filesystem: extfs
+          Supports d_type: true
+          Using metacopy: false
+          Native Overlay Diff: true
+          userxattr: false
+         Logging Driver: json-file
+         Cgroup Driver: systemd
+         Cgroup Version: 2
+         Plugins:
+          Volume: local
+          Network: bridge host ipvlan macvlan null overlay
+          Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
+         Swarm: inactive
+         Runtimes: io.containerd.runc.v2 runc
+         Default Runtime: runc
+         Init Binary: docker-init
+         containerd version: a1496014c916f9e62104b33d1bb5bd03b0858e59
+         runc version: v1.1.11-0-g4bccb38
+         init version: de40ad0
+         Security Options:
+          apparmor
+          seccomp
+           Profile: builtin
+          cgroupns
+         Kernel Version: 6.1.0-17-amd64
+         Operating System: Debian GNU/Linux 12 (bookworm)
+         OSType: linux
+         Architecture: x86_64
+         CPUs: 2
+         Total Memory: 1.921GiB
+         Name: debian
+         ID: 3eb5fae9-6504-4117-a93d-c099568e79c2
+         Docker Root Dir: /var/lib/docker
+         Debug Mode: false
+         Experimental: false
+         Insecure Registries:
+          127.0.0.0/8
+         Live Restore Enabled: false
+</details>
+
+
+3. <details><summary>Rocky Linux 9.3 (Blue Onyx) - click for details</summary>
+
+        Client: Docker Engine - Community
+         Version:    24.0.7
+         Context:    default
+         Debug Mode: false
+         Plugins:
+          buildx: Docker Buildx (Docker Inc.)
+            Version:  v0.11.2
+            Path:     /Users/user/.docker/cli-plugins/docker-buildx
+
+        Server:
+         Containers: 0
+          Running: 0
+          Paused: 0
+          Stopped: 0
+         Images: 0
+         Server Version: 24.0.7
+         Storage Driver: overlay2
+          Backing Filesystem: xfs
+          Supports d_type: true
+          Using metacopy: false
+          Native Overlay Diff: true
+          userxattr: false
+         Logging Driver: json-file
+         Cgroup Driver: systemd
+         Cgroup Version: 2
+         Plugins:
+          Volume: local
+          Network: bridge host ipvlan macvlan null overlay
+          Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
+         Swarm: inactive
+         Runtimes: io.containerd.runc.v2 runc
+         Default Runtime: runc
+         Init Binary: docker-init
+         containerd version: a1496014c916f9e62104b33d1bb5bd03b0858e59
+         runc version: v1.1.11-0-g4bccb38
+         init version: de40ad0
+         Security Options:
+          seccomp
+           Profile: builtin
+          selinux
+          cgroupns
+         Kernel Version: 5.14.0-362.13.1.el9_3.x86_64
+         Operating System: Rocky Linux 9.3 (Blue Onyx)
+         OSType: linux
+         Architecture: x86_64
+         CPUs: 2
+         Total Memory: 1.722GiB
+         Name: default
+         ID: 84a6e94a-7b3e-42ff-9370-1d0820695a55
+         Docker Root Dir: /var/lib/docker
+         Debug Mode: false
+         Experimental: false
+         Insecure Registries:
+          127.0.0.0/8
+         Live Restore Enabled: false
+</details>
 
 # Current limitations
 There is no client persistence when running up and down.

--- a/images/consul-client/Dockerfile
+++ b/images/consul-client/Dockerfile
@@ -3,5 +3,10 @@ FROM $BASE_IMAGE
 
 ENV container docker
 
+RUN mkdir -p /etc/systemd/resolved.conf.d
+
 # all non-scripts are 0644 (rw- r-- r--)
 COPY --chmod=0644 rootfs/etc/consul.d/* /etc/consul.d/
+COPY --chmod=0644 rootfs/etc/systemd/resolved.conf.d/* /etc/systemd/resolved.conf.d/
+
+RUN systemctl enable systemd-resolved.service

--- a/images/consul-client/rootfs/etc/consul.d/consul.hcl
+++ b/images/consul-client/rootfs/etc/consul.d/consul.hcl
@@ -9,3 +9,4 @@ addresses {
   dns = "0.0.0.0"
   http = "0.0.0.0"
 }
+recursors = ["127.0.0.11"]

--- a/images/consul-client/rootfs/etc/systemd/resolved.conf.d/consul.conf
+++ b/images/consul-client/rootfs/etc/systemd/resolved.conf.d/consul.conf
@@ -1,0 +1,4 @@
+[Resolve]
+DNS=127.0.0.1:8600
+DNSSEC=false
+Domains=~consul

--- a/images/nomad-client/Dockerfile
+++ b/images/nomad-client/Dockerfile
@@ -16,6 +16,9 @@ COPY --chmod=0644 rootfs/etc/systemd/system/* /etc/systemd/system/
 COPY --chmod=0644 rootfs/etc/cilium/* /etc/cilium/
 COPY --chmod=0644 rootfs/etc/docker/* /etc/docker/
 
+# enable onshot script to get consul dns working
+RUN systemctl enable consul-dns.service
+
 RUN sed -i "s/^User=.*\$/User=root/g" /etc/systemd/system/nomad.service \
     && sed -i "s/^Group=.*\$/Group=root/g" /etc/systemd/system/nomad.service
 
@@ -73,5 +76,5 @@ COPY --from=cilium/cilium:v1.13.9 /usr/bin/cilium* /usr/local/bin/
 COPY --from=cilium/cilium:v1.13.9 /usr/bin/hubble /usr/local/bin/
 COPY --chmod=0644 rootfs/opt/cni/config/* /opt/cilium/config/
 
-RUN systemctl ${CILIUM_SERVICE} cilium-mounts \
-    && systemctl ${CILIUM_SERVICE} cilium
+RUN systemctl ${CILIUM_SERVICE} cilium-mounts.service \
+    && systemctl ${CILIUM_SERVICE} cilium.service

--- a/images/nomad-client/Dockerfile
+++ b/images/nomad-client/Dockerfile
@@ -2,8 +2,8 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 ENV DOCKER_RELEASES=https://download.docker.com/linux/debian/dists/bullseye/pool/stable
-ARG CONTAINERD_VERSION=1.6.26-1
-ARG DOCKER_CE_VERSION=24.0.7-1
+ARG CONTAINERD_VERSION=1.6.31-1
+ARG DOCKER_CE_VERSION=26.0.1-1
 ENV container=docker
 
 # all non-scripts are 0644 (rw- r-- r--)

--- a/images/nomad-client/rootfs/etc/systemd/system/consul-dns.service
+++ b/images/nomad-client/rootfs/etc/systemd/system/consul-dns.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Configure systemd-resolved to use Consul DNS
+Requires=consul.service
+After=consul.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/consul-dns
+
+[Install]
+WantedBy=multi-user.target

--- a/images/nomad-client/rootfs/usr/local/bin/consul-dns
+++ b/images/nomad-client/rootfs/usr/local/bin/consul-dns
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# This script is used to ensure systemd-resolved is using consul DNS
+# and verify that it is working correctly.
+#
+
+log_info() {
+	echo "INFO: $1"
+}
+
+log_error() {
+	echo "ERROR: $1" >&2
+}
+
+wait_for_consul_dns() {
+	# Wait until consul DNS is up
+	for i in {1..5}; do
+		consul_dns_listening=$(ss -tulpn | grep LISTEN.*8600)
+		if [ $? -eq 0 ]; then
+			log_info "Consul DNS is up"
+			return
+		elif [ $i -eq 5 ]; then
+			log_error "Consul DNS is not up after 5 retries"
+			exit 1
+		fi
+		log_info "Consul DNS is not up, retrying in 5 seconds"
+		sleep 5
+	done
+}
+
+healthcheck() {
+	# Check systemd-resolved is active
+	systemd_resolved_is_active=$(systemctl is-active systemd-resolved 2>&1)
+	if [ "$systemd_resolved_is_active" != "active" ]; then
+		log_error "systemd-resolved is not active"
+		log_error "message - $systemd_resolved_is_active"
+		return 1
+	fi
+
+	# Check that the consul domain is set to global
+	resolvectl_domain=$(resolvectl domain 2>&1 | head -n 1)
+	if [ "$resolvectl_domain" != "Global: ~consul" ]; then
+		log_error "Consul domain is not set to global"
+		log_error "message - $resolvectl_domain"
+		return 1
+	fi
+
+	# Check that consul.service.consul resolves correctly
+	consul_dns=$(resolvectl query consul.service.consul 2>&1)
+	if [ $? -ne 0 ]; then
+		log_error "consul.service.consul not resolving correctly"
+		log_error "message - $consul_dns"
+		return 1
+	fi
+}
+
+# Restart systemd-resolved to apply the changes
+log_info "Restarting systemd-resolved"
+systemctl restart systemd-resolved
+
+wait_for_consul_dns
+
+# We can't symlink resolv.conf file in docker so we need to modify it directly
+log_info "Updating '/etc/resolv.conf' file"
+cat /run/systemd/resolve/stub-resolv.conf > /etc/resolv.conf
+
+# Run the healthcheck 5 times
+for i in {1..5}; do
+	healthcheck
+	if [ $? -eq 0 ]; then
+		log_info "Healthcheck passed"
+		exit 0
+	fi
+	echo "Healthcheck failed, retrying in 5 seconds"
+	sleep 5
+done
+
+log_error "Healthcheck failed after 5 retries"
+exit 1

--- a/scripts/check-image.sh
+++ b/scripts/check-image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+images=("$@")
+missing=()
+
+for image in "${images[@]}"; do
+    count=$(docker image inspect "${image}:${HIND_VERSION}" | jq ".|length")
+    if [ "${count:-0}" -eq 0 ]; then
+        missing+=("${image/\:[0-9]*.[0-9]*.[0-9]*/}")
+    fi
+done
+
+printf "%s\n" "${missing[@]}"

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -5,7 +5,7 @@ set -e
 script_dir="$(dirname "$0")"
 
 missing_images=$(
-    $script_dir/check-image.sh "hind.consul.server" "hind.nomad.server" "hind.nomad.client"
+    "$script_dir"/check-image.sh "hind.consul.server" "hind.nomad.server" "hind.nomad.client"
 )
 
 if [ -n "${missing_images}" ]; then
@@ -15,7 +15,7 @@ if [ -n "${missing_images}" ]; then
 fi
 
 network_name="hind"
-$script_dir/network-create.sh $network_name
+"$script_dir"/network-create.sh "$network_name"
 
 container_name="hind.consul.server"
 image_name="hind.consul.server"
@@ -24,7 +24,7 @@ if [ "${LISTEN_LOCALHOST:-0}" -eq 1 ]; then
 else
     args=("-p 8500:8500/tcp")
 fi
-$script_dir/docker-run.sh $container_name $network_name $image_name ${args[@]}
+"$script_dir"/docker-run.sh "$container_name" "$network_name" "$image_name" "${args[@]}"
 
 container_name="hind.nomad.server"
 image_name="hind.nomad.server"
@@ -33,7 +33,7 @@ if [ "${LISTEN_LOCALHOST:-0}" -eq 1 ]; then
 else
     args=("-p 4646:4646/tcp")
 fi
-$script_dir/docker-run.sh $container_name $network_name $image_name ${args[@]}
+"$script_dir"/docker-run.sh "$container_name" "$network_name" "$image_name" "${args[@]}"
 
 container_name="hind.nomad.client"
 image_name="hind.nomad.client"
@@ -43,6 +43,6 @@ args=(
     "-e CILIUM_IPV4_RANGE=${CILIUM_IPV4_RANGE}"
 )
 
-for count in $(seq -f "%02g" ${NOMAD_CLIENT_COUNT:-1}); do
-    $script_dir/docker-run.sh $container_name.$count $network_name $image_name ${args[@]}
+for count in $(seq -f "%02g" "${NOMAD_CLIENT_COUNT:-1}"); do
+    "$script_dir"/docker-run.sh "$container_name.$count" "$network_name" "$image_name" "${args[@]}"
 done

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -19,12 +19,20 @@ $script_dir/network-create.sh $network_name
 
 container_name="hind.consul.server"
 image_name="hind.consul.server"
-args=("-p 127.0.0.1:8500:8500/tcp")
+if [ "${LISTEN_LOCALHOST:-0}" -eq 1 ]; then
+    args=("-p 127.0.0.1:8500:8500/tcp")
+else
+    args=("-p 8500:8500/tcp")
+fi
 $script_dir/docker-run.sh $container_name $network_name $image_name ${args[@]}
 
 container_name="hind.nomad.server"
 image_name="hind.nomad.server"
-args=("-p 127.0.0.1:4646:4646/tcp")
+if [ "${LISTEN_LOCALHOST:-0}" -eq 1 ]; then
+    args=("-p 127.0.0.1:4646:4646/tcp")
+else
+    args=("-p 4646:4646/tcp")
+fi
 $script_dir/docker-run.sh $container_name $network_name $image_name ${args[@]}
 
 container_name="hind.nomad.client"

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -4,6 +4,16 @@ set -e
 
 script_dir="$(dirname "$0")"
 
+missing_images=$(
+    $script_dir/check-image.sh "hind.consul.server" "hind.nomad.server" "hind.nomad.client"
+)
+
+if [ -n "${missing_images}" ]; then
+    echo "Error detected missing 'hind' images"
+    echo "Please run 'make build' and try again"
+    exit 1
+fi
+
 network_name="hind"
 $script_dir/network-create.sh $network_name
 

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -3,8 +3,7 @@
 container_name="$1"
 network_name="$2"
 image_name="$3"
-shift; shift; shift
-args=($@)
+args=(${@:4})
 
 container_status=$(docker ps --no-trunc --format json \
     | jq "select(.Names == \"${container_name}\")")
@@ -15,8 +14,8 @@ function docker_run {
     --cgroupns=private \
     --detach \
     --init=false \
-    --name ${container_name} \
-    --network ${network_name} \
+    --name "${container_name}" \
+    --network "${network_name}" \
     --privileged \
     --restart on-failure:1 \
     --tmpfs /run \
@@ -26,16 +25,16 @@ function docker_run {
     --security-opt apparmor=unconfined \
     --volume /lib/modules:/lib/modules:ro \
     --volume /var \
-    ${args[@]} \
-    ${image_name}:${HIND_VERSION} > /dev/null
+    "${args[@]}" \
+    "${image_name}:${HIND_VERSION}" > /dev/null
 }
 
 if [ -z "${container_status}" ]; then
     echo -e "INFO\t container: creating $container_name"
-    docker_run $container_name $network_name $image_name ${args[@]}
+    docker_run "$container_name" "$network_name" "$image_name" "${args[@]}"
 elif [ "$(jq -rn "$container_status .State")" != "running" ]; then
     echo -e "INFO\t container: starting $container_name"
-    docker start $container_name
+    docker start "$container_name"
 elif [ "$(jq -rn "$container_status .State")" == "running" ]; then
     echo -e "INFO\t container: $container_name is already running"
 fi

--- a/scripts/network-create.sh
+++ b/scripts/network-create.sh
@@ -7,7 +7,7 @@ network_status=$(docker network ls --format json | jq "select(.Name == \"${netwo
 
 function create_network {
     echo -e "INFO\t network: creating $network_name"
-    docker network create ${network_name} > /dev/null
+    docker network create "${network_name}" > /dev/null
 }
 
 if [ -z "${network_status}" ]; then


### PR DESCRIPTION
new features:
- enable consul DNS in nomad client images
- option to disable nomad/consul port forwarded addresses from listening on all interfaces and only listen on localhost

updated default bins:
- consul v1.18.1
- nomad v1.7.6
- contained v1.6.31-1
- docker-ce v26.0.1-1

fixes/enhancements:
- update README.md with docker/linux versions that have been confirmed working with hind
- added missing docker image checks on cluster create
- linting fixes on shell files
- improve destroy logging to list container names of clients
