### PR TITLE
fix: rm should read config file

### DIFF
--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -189,9 +189,10 @@ func (m *Manager) Stop(ctx context.Context) error {
 }
 
 func (m *Manager) Delete(ctx context.Context) error {
-	// Load cluster config from disk if not already in memory
-	// This allows Delete to work even if Manager was created without loading config
-	if m.config == nil || m.config.Name == "" {
+	existed := m.ConfigFileExists()
+
+	if existed {
+		// Load existing config, else just use the config created by New()
 		cfg, err := m.loadConfig()
 		if err != nil {
 			return fmt.Errorf("failed to load cluster config: %w", err)


### PR DESCRIPTION
If you start a cluster with --clients > 1, then hind rm will only delete the first because it uses the default config without reading the config file. This reads the config file before operating. We may want to just load the config from New() if it exists.