### PR TITLE
fix: nomad unable to start

### DIFF
--- a/pkg/build/image/files/nodes/nomad/Dockerfile
+++ b/pkg/build/image/files/nodes/nomad/Dockerfile
@@ -44,6 +44,7 @@ RUN addgroup nomad \
     && adduser --system --group nomad \
     && mkdir -p /nomad/data \
     && mkdir -p /etc/nomad.d \
+    && chmod 0744 /etc/nomad.d \
     && chown -R nomad:nomad /nomad /etc/nomad.d
 
 # Set up certificates, base tools, and Nomad.


### PR DESCRIPTION
Nomad is unable to start because the nomad user doesn't have access to read /etc/nomad.d/nomad.hcl. This adds the exec permission to the directory, needed to list files inside of it so Nomad can see its config.